### PR TITLE
Entered new Fairteiler

### DIFF
--- a/index.html
+++ b/index.html
@@ -98,12 +98,13 @@ Dort kann sich jede*r Lebensmittel mitnehmen aber auch das abgeben,
 was er oder sie aufgrund z.B. eines anstehenden Urlaubs oder einer gefeierten Party,nicht mehr ben&ouml;tigt.
 Das allererste Ziel ist, dass keine Lebensmittel im M&uuml;ll landen.
 </p>
+<h3>Der Fairteiler</h3>
 <img src="bild_klein.jpg" align="right" hspace="10" vspace="10">
 <p>
-	Unser <b>Fairteiler</b> befindet sich im <b>
-	"<a target="_blank" href="http://www.ethnico.de/">Ethnico</a>" in der
-	<a target="_blank" href="http://www.openstreetmap.org/?mlat=49.4385&mlon=7.7673#map=16/49.4385/7.7673">Richard-Wagner-Stra&szlig;e 78</a></b><br>
-	Die &Ouml;ffnungszeiten sind Mo-Fr 11-18 Uhr und Samstag 11-15 Uhr.
+	Unser <b>Fairteiler</b> befindet sich im <b>Sozialkaufhaus Fairness der
+	"<a target="_blank" href="http://www.lebenswerk-eg.org/">Lebenswerk e.G.</a>" in der
+	<a target="_blank" href="https://www.openstreetmap.org/way/103144943">Beethoven-Stra&szlig;e 56</a></b><br>
+	Das Gesch&auml;ft, in dem der Fairteiler steht, &ouml;ffnnet montags bis freitags um 10 Uhr. Es schlie&szlig;t montags, mittwochs und donnerstags um 18 Uhr. Dienstags und freitags schließt es schon um 14 Uhr. Zu den genannten Zeiten k&ouml;nnt ihr dort Lebensmittel abholen oder abgeben, wenn sie übersch&uuml;ssig sind.
 </p>
 <p>
 Gerne können wir auch noch einen weiteren Fairteiler n&auml;her im Stadtzentrum aufstellen, um den sich dann jemand vor Ort k&uuml;mmern sollte.


### PR DESCRIPTION
Our Fairteiler moved to the Sozialkaufhaus Fairness. This version contains the new address together with a cool new h3-headline, an updated OpenStreetmap-Link, a link to Lebenswerk e.G. and the new schedule.
